### PR TITLE
Feat/redonewording

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4907,6 +4907,10 @@ packages:
     resolution: {integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=}
     dev: false
 
+  /lodash.throttle/4.1.1:
+    resolution: {integrity: sha1-wj6RtxAkKscMN/HhzaknTMOb8vQ=}
+    dev: false
+
   /lodash.uniq/4.5.0:
     resolution: {integrity: sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=}
     dev: true

--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -2,7 +2,6 @@ import {
   Flex, Heading, Button, Box,
   Icon,
   Spinner,
-  IconButton,
 } from '@chakra-ui/react';
 import { SiMicrosoftoffice } from 'react-icons/si';
 import { BsFillArrowDownCircleFill, BsArrowDownCircle } from 'react-icons/bs';

--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -21,12 +21,12 @@ const Header: React.FC = () => {
         {/* eslint-disable-next-line no-nested-ternary */}
         {isLoading ? <Spinner />
           : user ? (
-            <NextLink href="/panel" passHref>
-              <a><Button leftIcon={<Icon as={FaRegUser} color="black" boxSize={8} />} fontSize="24" p={8}>User Panel</Button></a>
+            <NextLink href="/panel">
+              <a><Button leftIcon={<Icon as={FaRegUser} color="white" boxSize={8} />} fontSize="24" p={8}>User Panel</Button></a>
             </NextLink>
           )
             : (
-              <Button onClick={signin} leftIcon={<Icon as={SiMicrosoftoffice} color="black" boxSize={8} />} fontSize="24" p={8}>Sign in with Office</Button>
+              <Button onClick={signin} leftIcon={<Icon as={SiMicrosoftoffice} color="white" boxSize={8} />} fontSize="24" p={8}>Sign in with Office</Button>
             )}
       </Flex>
       <Flex direction="row" mt="-30px" justify="center" zIndex={105} position="sticky" bottom={2}>

--- a/src/components/Home/Header.tsx
+++ b/src/components/Home/Header.tsx
@@ -2,6 +2,7 @@ import {
   Flex, Heading, Button, Box,
   Icon,
   Spinner,
+  IconButton,
 } from '@chakra-ui/react';
 import { SiMicrosoftoffice } from 'react-icons/si';
 import { BsFillArrowDownCircleFill, BsArrowDownCircle } from 'react-icons/bs';

--- a/src/components/Layouts/Base.tsx
+++ b/src/components/Layouts/Base.tsx
@@ -17,7 +17,7 @@ const BaseLayout: React.FC<Props> = ({ children, isLoading }) => (
     <Box w="100%" zIndex={99}>
       <NavBar />
     </Box>
-    <Box w="60%">
+    <Box w="90%">
       {isLoading ? <Center><Spinner size="xl" /></Center> : children}
     </Box>
     <Spacer />

--- a/src/components/Layouts/Base.tsx
+++ b/src/components/Layouts/Base.tsx
@@ -17,7 +17,7 @@ const BaseLayout: React.FC<Props> = ({ children, isLoading }) => (
     <Box w="100%" zIndex={99}>
       <NavBar />
     </Box>
-    <Box w="90%">
+    <Box w={['90%', null, '80%', '70%']}>
       {isLoading ? <Center><Spinner size="xl" /></Center> : children}
     </Box>
     <Spacer />

--- a/src/components/UserPanel/HasTicket.tsx
+++ b/src/components/UserPanel/HasTicket.tsx
@@ -8,7 +8,7 @@ const HasTicket: React.FC = () => {
   return (
     <>
       <Flex direction="column" align="center" justify="center" m={5}>
-        <Heading as="h2" my={3}>Your Ticket</Heading>
+        <Heading as="h2" my={3} textAlign="center">Your Ticket</Heading>
         <QR jwt={ticket.jwt} />
       </Flex>
       <MoreInfo />

--- a/src/components/UserPanel/NoTicket.tsx
+++ b/src/components/UserPanel/NoTicket.tsx
@@ -1,18 +1,19 @@
-import { Flex, Heading } from '@chakra-ui/react';
+import {
+  Flex, Heading, Text,
+} from '@chakra-ui/react';
 import CheckoutWrapper from 'components/Checkout/CheckoutWrapper';
 import MoreInfo from './MoreInfo';
 
 const NoTicket: React.FC = () => (
-  <Flex w="100%" justify="center" direction="column" p={5}>
-
-    <Heading as="h2">More information</Heading>
-    <MoreInfo />
-
-    <Heading as="h2" mb={3}>Buy your ticket</Heading>
+  <Flex w="100%" justify="center" align="center" direction="column" p={5}>
+    <Heading as="h2" mb={3}><Text textAlign="center">Buy your ticket for £30</Text></Heading>
     <Flex flexFlow="column nowrap" justify="center" align="center" alignSelf="center" minW="300px" maxW="500px" w="70%">
-      <Heading as="h4" mb={3}>Paying £30</Heading>
       <CheckoutWrapper />
     </Flex>
+    <Flex height="50px" />
+    <Heading as="h2" textAlign="center">More information</Heading>
+    <MoreInfo />
+
   </Flex>
 );
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,7 +5,6 @@ import HomeLayout from 'components/Layouts/Home';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useToast } from '@chakra-ui/react';
-import { Element } from 'react-scroll';
 
 const Home: NextPage = () => {
   const router = useRouter();

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -5,6 +5,7 @@ import HomeLayout from 'components/Layouts/Home';
 import { useRouter } from 'next/router';
 import { useEffect } from 'react';
 import { useToast } from '@chakra-ui/react';
+import { Element } from 'react-scroll';
 
 const Home: NextPage = () => {
   const router = useRouter();

--- a/src/pages/terms.tsx
+++ b/src/pages/terms.tsx
@@ -165,7 +165,7 @@ You may only purchase one (1) ticket.
 
 const Terms: NextPage = () => (
   <BaseLayout>
-    <Heading as="h1" size="2xl">Terms and Conditions</Heading>
+    <Heading as="h1" size="2xl" textAlign="center">Terms and Conditions</Heading>
     <Box>
       <MarkdownRenderer
         components={{


### PR DESCRIPTION
Changed one number in the base layout - for some reason width was at 60% for the children of any page using base layout, i.e privacy policy, user panel, etc, hence looked terrible on mobile? Also doesn't affect anything on desktop save privacy policy and t&cs take up a bit more of the width of the screen, which looks fine. 
Then put the payment above more info on the user page for NoTicket, because I was a retard before.
All hail President Nick.